### PR TITLE
Display fix

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -57,6 +57,10 @@ void Application::run() {
                 window.close();
             else if (event.type == sf::Event::Resized) {
                 simDisplay.updateViewport(event.size.width, event.size.height);
+
+                ImGui::SFML::Update(window, deltaClock.restart());
+                statsWindow.draw(event.size.width, event.size.height);
+                ImGui::SFML::Render(window);
              }
         }   
 

--- a/src/display/statsWindow.cpp
+++ b/src/display/statsWindow.cpp
@@ -32,6 +32,7 @@ void StatsWindow::draw() {
     pollinationCountInfo << "Flowers pollinated: " << metrics->pollinated_count;
 
     // configure window
+    ImGui::SetNextWindowPos(ImVec2(0.2, 0.2), ImGuiCond_Once);
     ImGui::SetNextWindowSize(ImVec2(0.0, 0.0));  // auto resize
     ImGui::Begin("Simulation statistics");
     ImGui::Text(runTimeInfo.str().c_str());

--- a/src/display/statsWindow.cpp
+++ b/src/display/statsWindow.cpp
@@ -37,7 +37,7 @@ void StatsWindow::draw(int windowX, int windowY) {
     ImGui::SetNextWindowSize(ImVec2(0.0, 0.0));  // auto resize
 
     ImGui::Begin("Simulation statistics");
-    // move window if outside visible area
+    // move window if needed, and outside visible area
     bool checkWindowPosition = windowX != -1 and windowY != -1;
     if (checkWindowPosition) {
         auto statsWindowPos = ImGui::GetWindowPos();

--- a/src/display/statsWindow.cpp
+++ b/src/display/statsWindow.cpp
@@ -21,7 +21,7 @@ StatsWindow::StatsWindow(shared_ptr<Metrics> metrics) {
     this->metrics = metrics;
 }
 
-void StatsWindow::draw() {
+void StatsWindow::draw(int windowX, int windowY) {
     // create info strings
     std::stringstream runTimeInfo;
     std::stringstream hiveNectarInfo;
@@ -32,9 +32,21 @@ void StatsWindow::draw() {
     pollinationCountInfo << "Flowers pollinated: " << metrics->pollinated_count;
 
     // configure window
-    ImGui::SetNextWindowPos(ImVec2(0.2, 0.2), ImGuiCond_Once);
+    auto defaultPos = ImVec2(20, 20);
+    ImGui::SetNextWindowPos(defaultPos, ImGuiCond_Once);  // set up initial position
     ImGui::SetNextWindowSize(ImVec2(0.0, 0.0));  // auto resize
+
     ImGui::Begin("Simulation statistics");
+    // move window if outside visible area
+    bool checkWindowPosition = windowX != -1 and windowY != -1;
+    if (checkWindowPosition) {
+        auto statsWindowPos = ImGui::GetWindowPos();
+        if (statsWindowPos.x > windowX or statsWindowPos.y > windowY) {
+            ImGui::SetWindowPos(defaultPos);
+        }
+    }
+    
+    // set up window contents
     ImGui::Text(runTimeInfo.str().c_str());
     ImGui::Text(hiveNectarInfo.str().c_str());
     ImGui::Text(pollinationCountInfo.str().c_str());

--- a/src/display/statsWindow.hpp
+++ b/src/display/statsWindow.hpp
@@ -30,8 +30,11 @@ class StatsWindow {
         StatsWindow(shared_ptr<Metrics> metrics);
         /**
          * @brief Draw the statistics window.
+         * 
+         * @param windowX The width of the window that the Stats Window will be drawn to, in pixels. -1 if not specified
+         * @param windowY The height of the window that the Stats Window will be drawn to, in pixels. -1 if not specified
          */
-        void draw();
+        void draw(int windowX = -1, int windowY = -1);
     private:
         /// @brief metrics and statistics about the simulation
         shared_ptr<Metrics> metrics;


### PR DESCRIPTION
Fixes https://github.com/robertovers/nectar/issues/33#issue-1376934020
Stats window is initialised in upper left corner of window. When resizing, if stats window is outside the visible area, it is moved back to its initial position. Doesn't affect the user choosing to the the stats window outside of the main window (until the window is resized).